### PR TITLE
fix: refactor clients in solid service

### DIFF
--- a/packages/inrupt-solid-service/lib/solid-sdk.service.ts
+++ b/packages/inrupt-solid-service/lib/solid-sdk.service.ts
@@ -17,13 +17,9 @@ export class SolidSDKService implements SolidService {
   /**
    * Instantiates a solid sdk service.
    */
-  constructor (private defaultClientName: string, private clients?: { [key: string]: Client }) {
+  constructor (private client: Client) {
 
-    for (const client in clients) {
-
-      if (clients[client].clientSecret && !clients[client].clientId) throw new Error('clientId must be set if clientSecret is set');
-
-    }
+    if (client.clientSecret && !client.clientId) throw new Error('clientId must be set if clientSecret is set');
 
   }
 
@@ -237,16 +233,12 @@ export class SolidSDKService implements SolidService {
 
     }
 
-    const client = this.clients && this.clients[issuer.uri]
-      ? this.clients[issuer.uri]
-      : { clientName: this.defaultClientName };
-
     await login({
       oidcIssuer: issuer.uri,
       redirectUrl: window.location.href,
-      clientName: client.clientName,
-      clientId: client.clientId,
-      clientSecret: client.clientSecret,
+      clientName: this.client.clientName,
+      clientId: this.client.clientId,
+      clientSecret: this.client.clientSecret,
     });
 
   }
@@ -262,16 +254,12 @@ export class SolidSDKService implements SolidService {
 
     }
 
-    const client = this.clients && this.clients[issuer.uri]
-      ? this.clients[issuer.uri]
-      : { clientName: this.defaultClientName };
-
     await login({
       oidcIssuer: issuer.uri,
       redirectUrl: window.location.href,
-      clientName: client.clientName,
-      clientId: client.clientId,
-      clientSecret: client.clientSecret,
+      clientName: this.client.clientName,
+      clientId: this.client.clientId,
+      clientSecret: this.client.clientSecret,
     });
 
   }

--- a/packages/inrupt-solid-service/package.json
+++ b/packages/inrupt-solid-service/package.json
@@ -75,10 +75,10 @@
     "testEnvironment": "<rootDir>/jest.env.js",
     "coverageThreshold": {
       "global": {
-        "branches": 38.33,
-        "functions": 51.85,
-        "lines": 43.24,
-        "statements": 44.06
+        "branches": 36.53,
+        "functions": 62.96,
+        "lines": 55.55,
+        "statements": 55.26
       }
     },
     "setupFiles": [


### PR DESCRIPTION
an app using this service should now be able to specify a single client, with client name, id (optionally: secret). the client id would most often be a URL of a client id document.

the old implementation was specifically for the publiq poc, but makes little sense outside of that. there was no way to provide a generic client for the app, only a name. since we don't have a need for supporting different clients for different IDPs at the moment, this code is removed. could be re-added later if we find a need for this again